### PR TITLE
Add Route [new entity bean created]

### DIFF
--- a/src/main/java/com/example/travelDiary/application/service/travel/PlaceAccessService.java
+++ b/src/main/java/com/example/travelDiary/application/service/travel/PlaceAccessService.java
@@ -1,0 +1,66 @@
+package com.example.travelDiary.application.service.travel;
+
+import com.example.travelDiary.domain.model.location.Place;
+import com.example.travelDiary.domain.persistence.location.PlaceRepository;
+import com.example.travelDiary.presentation.dto.travel.PlaceUpdateRequest;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+public class PlaceAccessService {
+    private final PlaceRepository placeRepository;
+    private final ConversionService conversionService;
+
+    public PlaceAccessService(PlaceRepository placeRepository, ConversionService conversionService) {
+        this.placeRepository = placeRepository;
+        this.conversionService = conversionService;
+    }
+
+    @Transactional
+    public Place reassignPlace(PlaceUpdateRequest request) {
+        Place place = conversionService.convert(request, Place.class);
+        assert place != null;
+        Place newPlace = placeRepository
+                .findByGoogleMapsKeyId(place.getGoogleMapsKeyId())
+                .orElse(placeRepository.save(place));
+
+        return newPlace;
+    }
+
+    @Transactional
+    public Place updatePlace(PlaceUpdateRequest updateRequest) {
+        Place updatedPlace = conversionService.convert(updateRequest, Place.class);
+        assert updatedPlace != null;
+        Place existingPlace = placeRepository
+                .findByGoogleMapsKeyId(updatedPlace.getGoogleMapsKeyId())
+                .orElseThrow(() -> new EntityNotFoundException("Place not found"));
+        existingPlace.setName(updatedPlace.getName());
+        existingPlace.setCountry(updatedPlace.getCountry());
+        existingPlace.setLatitude(updatedPlace.getLatitude());
+        existingPlace.setLongitude(updatedPlace.getLongitude());
+        return placeRepository.save(existingPlace);
+    }
+
+    @Transactional
+    public Place createPlace(Place placeFromCreatedSchedule) {
+        Place place = placeFromCreatedSchedule;
+        Optional<Place> existingPlaceOpt = placeRepository.findByGoogleMapsKeyId(place.getGoogleMapsKeyId());
+
+        if (existingPlaceOpt.isPresent()) {
+            place = existingPlaceOpt.get();
+        } else {
+            placeRepository.save(place);
+        }
+
+        return place;
+    }
+
+    public void deletePlace(Place place) {
+        placeRepository.deleteById(place.getId());
+    }
+
+}

--- a/src/main/java/com/example/travelDiary/application/service/travel/RouteAccessService.java
+++ b/src/main/java/com/example/travelDiary/application/service/travel/RouteAccessService.java
@@ -1,0 +1,59 @@
+package com.example.travelDiary.application.service.travel;
+
+import com.example.travelDiary.domain.model.travel.Route;
+import com.example.travelDiary.domain.persistence.travel.RouteRepository;
+import com.example.travelDiary.presentation.dto.travel.RouteUpdateRequest;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+public class RouteAccessService {
+
+    private final RouteRepository routeRepository;
+    private final ConversionService conversionService;
+
+    public RouteAccessService(RouteRepository routeRepository, ConversionService conversionService) {
+        this.routeRepository = routeRepository;
+        this.conversionService = conversionService;
+    }
+
+    @Transactional
+    public Route updateRoute(RouteUpdateRequest request) {
+        Route newRoute = conversionService.convert(request, Route.class);
+        Optional<Route> existingRouteOpt = routeRepository.findById(request.getId());
+
+        if (existingRouteOpt.isPresent()) {
+            Route existingRoute = existingRouteOpt.get();
+
+            assert newRoute != null;
+            newRoute.setId(existingRoute.getId());
+
+            return routeRepository.save(newRoute);
+        } else {
+            throw new IllegalArgumentException("Route with ID " + request.id + " does not exist.");
+        }
+    }
+
+    @Transactional
+    public void removeRoute(Route route) {
+        routeRepository.delete(route);
+    }
+
+    @Transactional
+    public Route createEmptyRoute() {
+        Route route = new Route();
+        return routeRepository.save(route);
+    }
+
+    @Transactional
+    public void resetRoute(Route route) {
+        route.setDurationOfTravel(null);
+        route.setDistanceOfTravel(null);
+        route.setMethodOfTravel(null);
+        route.setGoogleEncodedPolyline(null);
+        routeRepository.save(route);
+    }
+}

--- a/src/main/java/com/example/travelDiary/application/service/travel/ScheduleAccessService.java
+++ b/src/main/java/com/example/travelDiary/application/service/travel/ScheduleAccessService.java
@@ -119,6 +119,8 @@ public class ScheduleAccessService {
         assert place != null;
         Schedule schedule = scheduleRepository.findById(scheduleId).orElseThrow(() -> new EntityNotFoundException("Schedule not found"));
         schedule.setPlace(place);
+        routeAccessService.resetRoute(schedule.getInwardRoute());
+        routeAccessService.resetRoute(schedule.getOutwardRoute());
         return scheduleRepository.save(schedule);
     }
 

--- a/src/main/java/com/example/travelDiary/application/service/travel/TravelPlanAccessService.java
+++ b/src/main/java/com/example/travelDiary/application/service/travel/TravelPlanAccessService.java
@@ -29,6 +29,7 @@ public class TravelPlanAccessService {
         PageRequest pageRequest = PageRequest.of(pageNumber, pageSize);
         return travelPlanRepository.findAllByNameContaining(name, pageRequest);
     }
+
     public TravelPlan getTravelPlan(UUID planId) {
         return travelPlanRepository.findById(planId).orElseThrow();
     }
@@ -51,8 +52,13 @@ public class TravelPlanAccessService {
         return travelPlan;
     }
 
-    private static void updateNonNullFields(TravelPlanUpsertRequestDTO request, TravelPlan travelPlan) {
-        // Map non-null fields from the request DTO to the entity
+    public TravelPlan importPlan (TravelPlan travelPlan) {
+        return travelPlanRepository.save(travelPlan);
+    }
+
+
+    private void updateNonNullFields(TravelPlanUpsertRequestDTO request, TravelPlan travelPlan) {
+
         if (request.getEndDate() != null) {
             travelPlan.setTravelEndDate(request.getEndDate());
         }
@@ -64,5 +70,3 @@ public class TravelPlanAccessService {
         }
     }
 }
-
-//   travelPlan/{travelPlanId}/schedule/order/{order_number}

--- a/src/main/java/com/example/travelDiary/domain/model/travel/Route.java
+++ b/src/main/java/com/example/travelDiary/domain/model/travel/Route.java
@@ -1,10 +1,9 @@
 package com.example.travelDiary.domain.model.travel;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.example.travelDiary.domain.model.location.Place;
+import jakarta.persistence.*;
 
+import java.math.BigDecimal;
 import java.time.LocalTime;
 import java.util.UUID;
 
@@ -14,7 +13,16 @@ public class Route {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    private LocalTime durationOfTravel;
+    public UUID outBoundScheduleId;
 
+    public UUID inBoundScheduleId;
+
+    public LocalTime durationOfTravel;
+
+    public BigDecimal distanceOfTravel;
+
+    public String methodOfTravel;
+
+    public String GoogleEncodedPolyline;
 
 }

--- a/src/main/java/com/example/travelDiary/domain/persistence/travel/RouteRepository.java
+++ b/src/main/java/com/example/travelDiary/domain/persistence/travel/RouteRepository.java
@@ -1,0 +1,9 @@
+package com.example.travelDiary.domain.persistence.travel;
+
+import com.example.travelDiary.domain.model.travel.Route;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface RouteRepository extends JpaRepository<Route, UUID> {
+}

--- a/src/main/java/com/example/travelDiary/presentation/controller/travel/ScheduleController.java
+++ b/src/main/java/com/example/travelDiary/presentation/controller/travel/ScheduleController.java
@@ -1,8 +1,10 @@
 package com.example.travelDiary.presentation.controller.travel;
 
 import com.example.travelDiary.application.service.travel.ScheduleAccessService;
+import com.example.travelDiary.domain.model.travel.Route;
 import com.example.travelDiary.domain.model.travel.Schedule;
 import com.example.travelDiary.presentation.dto.travel.PlaceUpdateRequest;
+import com.example.travelDiary.presentation.dto.travel.RouteUpdateRequest;
 import com.example.travelDiary.presentation.dto.travel.ScheduleInsertRequest;
 import com.example.travelDiary.presentation.dto.travel.ScheduleMetadataUpdateRequest;
 import org.springframework.data.domain.Page;
@@ -68,5 +70,12 @@ public class ScheduleController {
     public Schedule reassignPlaceOnSchedule (@PathVariable(value = "travelPlanId") UUID travelPlanId, @RequestBody PlaceUpdateRequest request) {
         return scheduleAccessService.reassignPlace(request.scheduleId, request);
     }
+
+    //update Route
+    @PatchMapping("/udpate_route_details")
+    public Route updateRoute(@PathVariable(value = "travelPlanId") UUID travelPlanId, @RequestBody RouteUpdateRequest request) {
+        return scheduleAccessService.updateRouteDetails(request);
+    }
+
 
 }

--- a/src/main/java/com/example/travelDiary/presentation/controller/travel/ScheduleController.java
+++ b/src/main/java/com/example/travelDiary/presentation/controller/travel/ScheduleController.java
@@ -57,6 +57,8 @@ public class ScheduleController {
         return scheduleAccessService.getSchedule(scheduleId);
     }
 
+    //update PLACE
+
     @PatchMapping("/update_all_linked_place")
     public List<Schedule> modifyPlaceOnAllLinkedSchedule (@PathVariable(value = "travelPlanId") UUID travelPlanId, @RequestBody PlaceUpdateRequest request) {
         return scheduleAccessService.updatePlace(request);

--- a/src/main/java/com/example/travelDiary/presentation/converter/ConversionConfig.java
+++ b/src/main/java/com/example/travelDiary/presentation/converter/ConversionConfig.java
@@ -15,6 +15,7 @@ public class ConversionConfig implements WebMvcConfigurer {
         registry.addConverter(new ReviewUpsertRequestToReview());
         registry.addConverter(new ScheduleMetadataUpdateRequestToEntity());
         registry.addConverter(new PlaceUpdateRequestToEntity());
+        registry.addConverter(new ReviewUpsertRequestToReview());
     }
 
 }

--- a/src/main/java/com/example/travelDiary/presentation/converter/RouteUpdateRequestToEntity.java
+++ b/src/main/java/com/example/travelDiary/presentation/converter/RouteUpdateRequestToEntity.java
@@ -1,0 +1,53 @@
+package com.example.travelDiary.presentation.converter;
+
+import com.example.travelDiary.domain.model.travel.Route;
+import com.example.travelDiary.presentation.dto.travel.RouteUpdateRequest;
+import org.springframework.core.convert.converter.Converter;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public class RouteUpdateRequestToEntity implements Converter<RouteUpdateRequest, Route> {
+    @Override
+    public Route convert(RouteUpdateRequest source) {
+        Route route = new Route();
+
+        if (source.getId() != null) {
+            route.setId(source.getId());
+        } else {
+            route.setId(UUID.randomUUID());
+        }
+
+        if (source.getOutBoundScheduleId() != null) {
+            route.setOutBoundScheduleId(source.getOutBoundScheduleId());
+        }
+
+        if (source.getInBoundScheduleId() != null) {
+            route.setInBoundScheduleId(source.getInBoundScheduleId());
+        }
+
+        if (source.getDurationOfTravel() != null) {
+            route.setDurationOfTravel(source.getDurationOfTravel());
+        }
+
+        if (source.getDistanceOfTravel() != null) {
+            route.setDistanceOfTravel(source.getDistanceOfTravel());
+        } else {
+            route.setDistanceOfTravel(BigDecimal.ZERO);
+        }
+
+        if (source.getMethodOfTravel() != null) {
+            route.setMethodOfTravel(source.getMethodOfTravel());
+        } else {
+            route.setMethodOfTravel("");
+        }
+
+        if (source.getGoogleEncodedPolyline() != null) {
+            route.setGoogleEncodedPolyline(source.getGoogleEncodedPolyline());
+        } else {
+            route.setGoogleEncodedPolyline("");
+        }
+
+        return route;
+    }
+}

--- a/src/main/java/com/example/travelDiary/presentation/dto/travel/RouteUpdateRequest.java
+++ b/src/main/java/com/example/travelDiary/presentation/dto/travel/RouteUpdateRequest.java
@@ -1,19 +1,15 @@
-package com.example.travelDiary.domain.model.travel;
+package com.example.travelDiary.presentation.dto.travel;
 
-import com.example.travelDiary.domain.model.location.Place;
-import jakarta.persistence.*;
 import lombok.Data;
 
 import java.math.BigDecimal;
 import java.time.LocalTime;
 import java.util.UUID;
 
-@Entity
 @Data
-public class Route {
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+public class RouteUpdateRequest {
+
+    public UUID id;
 
     public UUID outBoundScheduleId;
 

--- a/src/main/java/com/example/travelDiary/presentation/dto/travel/ScheduleInsertRequest.java
+++ b/src/main/java/com/example/travelDiary/presentation/dto/travel/ScheduleInsertRequest.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 @Data
 public class ScheduleInsertRequest {
     public Place place;
+    public UUID previousScheduleId;
     public Boolean isActuallyVisited;
     public LocalDate travelDate;
     public Integer orderOfTravel;


### PR DESCRIPTION
Added a new Entity Route.

Route represents the travel route between places, including duration, distance, and method of travel.

A single Route is connected to 2 different Schedules, as inbound/outbound, connected via cascadeType.all to ensure changes from one side will be reflected on the other.

--entity details--
Fields:

id (UUID): Primary key.
outBoundScheduleId (UUID): Identifier for the outbound schedule.
inBoundScheduleId (UUID): Identifier for the inbound schedule.
durationOfTravel (LocalTime): Duration of the travel.
distanceOfTravel (BigDecimal): Distance of the travel.
methodOfTravel (String): Method of travel (e.g., car, train, walking).
googleEncodedPolyline (String): Encoded polyline for the route on Google Maps.
-- Modifications --

CreateSchedule now generates an empty route between the previous schedule and the newly created schedule
UpdatePlace now resets any existing routes for affected schedules.
reassignPlace now resets any existing routes for affected schedule.